### PR TITLE
Improvements

### DIFF
--- a/example.html
+++ b/example.html
@@ -1,11 +1,48 @@
-<script type="text/javascript" src="js/jquery-1.11.3.min.js"></script>
-<script type="text/javascript" src="js/bootstrap.min.js"></script>
-<script type="text/javascript" src="js/FileSaver.min.js"></script>
-<script type="text/javascript" src="js/jszip.min.js"></script>
-<script type="text/javascript" src="js/API.js"></script>
-<script>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>GitZip Example</title>
+  <script type="text/javascript" src="js/jquery-1.11.3.min.js"></script>
+  <script type="text/javascript" src="js/FileSaver.min.js"></script>
+  <script type="text/javascript" src="js/jszip.min.js"></script>
+  <script type="text/javascript" src="js/API.js"></script>
+</head>
+<body>
+  <script>
+  'use strict';
 
- // call GitZip.zipRepo(url) with your url path to your github folder
- // such as GitZip.zipRepo('https://github.com/kennethgoodman/gitzip/tree/gh-pages/js')
+  // call GitZip.zipRepo(url) with your url path to your github folder
+  // such as GitZip.zipRepo('https://github.com/kennethgoodman/gitzip/tree/gh-pages/js')
 
-</script>
+  var exampleRx = /^\s*GitZip\.zipRepo\("([^"]+)"\);$/gm;
+
+  var createButtons = function (urls) {
+    urls.forEach(function (url) {
+      var button = document.createElement('button');
+      button.textContent = url;
+      button.addEventListener('click', function () {
+        GitZip.zipRepo(url);
+      });
+      document.body.appendChild(button);
+      document.body.appendChild(document.createElement('br'));
+    });
+  };
+
+  // fetches example URLs from the README
+  var req = new XMLHttpRequest();
+  req.open('GET', 'README.md');
+  req.overrideMimeType('text/plain');
+  req.onload = function (ev) {
+    var examples = [];
+    var match;
+    while (match = exampleRx.exec(this.responseText)) {
+      examples.push(match[1]);
+    }
+    createButtons(examples);
+  };
+  req.send();
+
+  </script>
+</body>
+</html>

--- a/js/API.js
+++ b/js/API.js
@@ -72,7 +72,10 @@
                 progressCallback.call(callbackScope, 'done', 'Saving File.');
             });
             setTimeout(function(){
+                // link has to be in the page DOM for it to work with Firefox
+                document.body.appendChild(down);
                 down.click();
+                down.parentNode.removeChild(down);
             },100);
         }
     }


### PR DESCRIPTION
Hi,
I was reading through your code and decided to tamper with your example page to have it fetch URLs from the README.md. Then I discovered some bugs with Firefox.

I fixed an issue with the `downloadZip` function where, apparently, Firefox needs the link to be in the page’s DOM in order to catch the click onto it.

However, one problem I did not fix is Firefox displaying the example html file (`"https://github.com/KinoLien/gitzip/blob/master/example.html"`) instead of prompting for download. This is by design, according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download :
 > This attribute is only honored for links to resources with the same-origin.

I have no idea how to find a workaround, but I’ll keep investigating.

If you’re only interested in one of my two commits, just tell me and I’ll make a separate pull request.