### PR TITLE
For #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ It can make sub-folder/sub-directory of github repository as zip and download it
 
 ##### Examples
 
-	https://kinolien.github.com/gitzip?download=/KinoLien/gitzip
-	https://kinolien.github.com/gitzip?download=KinoLien/gitzip
-	https://kinolien.github.com/gitzip?download=https://github.com/KinoLien/gitzip/tree/gh-pages
-	https://kinolien.github.com/gitzip?download=/KinoLien/gitzip&token=12345yourtoken6789
-	https://kinolien.github.com/gitzip?download=/d3/d3/tree/master/test&token=12345yourtoken6789
-	https://kinolien.github.com/gitzip?download=https://github.com/d3/d3/tree/master/test&token=12345yourtoken6789
+ * https://kinolien.github.com/gitzip/?download=/KinoLien/gitzip
+ * https://kinolien.github.com/gitzip/?download=KinoLien/gitzip
+ * https://kinolien.github.com/gitzip/?download=https://github.com/KinoLien/gitzip/tree/gh-pages
+ * https://kinolien.github.com/gitzip/?download=/KinoLien/gitzip&token=12345yourtoken6789
+ * https://kinolien.github.com/gitzip/?download=/d3/d3/tree/master/test&token=12345yourtoken6789
+ * https://kinolien.github.com/gitzip/?download=https://github.com/d3/d3/tree/master/test&token=12345yourtoken6789
 


### PR DESCRIPTION
Changed pre-formatted to a list. That makes the links clickable. Applied https://github.com/KinoLien/gitzip/issues/9: added slashes between `https://kinolien.github.com/gitzip` and `?download=`